### PR TITLE
Fix bug showing snap points

### DIFF
--- a/Sources/Snappy/SnappyView.swift
+++ b/Sources/Snappy/SnappyView.swift
@@ -93,7 +93,6 @@ public struct SnappyView<Content: View, SnapPointContent: View>: View {
                 })
                 .onPreferenceChange(SnappyViewSizePreferenceKey.self) { size in
                     let limitOfMovement = limitOfMovement(in: geometry)
-                    print(limitOfMovement)
                     let limitedRect = CGRect(x: limitOfMovement.minX,
                                              y: limitOfMovement.minY,
                                              width: limitOfMovement.width - size.width,
@@ -108,7 +107,7 @@ public struct SnappyView<Content: View, SnapPointContent: View>: View {
             
                 .offset(constrainTranslation(translation + rememberedTranslation))
                 .overlay {
-                    if let snapPointContent = snapPointContent {
+                    if shouldShowSnapPoints, let snapPointContent = snapPointContent {
                         ForEach(Array(snapPoints), id: \.self) { pt in
                             snapPointContent
                                 .offset(x: pt.x * limitOfMovement(in: geometry).width, y: pt.y * limitOfMovement(in: geometry).height)


### PR DESCRIPTION
## Summary
- remove leftover debug print in `SnappyView`
- show snap point overlay only when requested

## Testing
- `swift build` *(fails: no module 'SwiftUI')*

------
https://chatgpt.com/codex/tasks/task_e_68847a410f08832aba61c0bcad8b2d8f