### PR TITLE
Add unit tests for additive arithmetic

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -19,5 +19,9 @@ let package = Package(
             name: "Snappy"
             , exclude: ["SnappyExample"]
         ),
+        .testTarget(
+            name: "SnappyTests",
+            dependencies: ["Snappy"]
+        ),
     ]
 )

--- a/Tests/SnappyTests/AdditiveArithmeticTests.swift
+++ b/Tests/SnappyTests/AdditiveArithmeticTests.swift
@@ -1,0 +1,33 @@
+import XCTest
+@testable import Snappy
+
+final class AdditiveArithmeticTests: XCTestCase {
+    func testCGPointAdditionAndSubtraction() {
+        let p1 = CGPoint(x: 1, y: 2)
+        let p2 = CGPoint(x: 3, y: 4)
+        XCTAssertEqual(p1 + p2, CGPoint(x: 4, y: 6))
+        XCTAssertEqual(p2 - p1, CGPoint(x: 2, y: 2))
+        XCTAssertEqual(CGPoint.zero + .zero, .zero)
+    }
+
+    func testCGSizeAdditionAndSubtraction() {
+        let s1 = CGSize(width: 5, height: 10)
+        let s2 = CGSize(width: 2, height: 3)
+        XCTAssertEqual(s1 + s2, CGSize(width: 7, height: 13))
+        XCTAssertEqual(s1 - s2, CGSize(width: 3, height: 7))
+        XCTAssertEqual(CGSize.zero + .zero, .zero)
+    }
+
+    func testSetAdditiveArithmetic() {
+        let setA: Set<Int> = [1, 2]
+        let setB: Set<Int> = [2, 3]
+
+        XCTAssertEqual(setA + setB, [1, 2, 3])
+        XCTAssertEqual(setA - setB, [1])
+
+        XCTAssertEqual(setA + 3, [1, 2, 3])
+        XCTAssertEqual(setA - 1, [2])
+
+        XCTAssertEqual(Set<Int>.zero, [])
+    }
+}


### PR DESCRIPTION
## Summary
- add `SnappyTests` test target
- create tests for additive arithmetic operators on `CGPoint`, `CGSize`, and `Set`

## Testing
- `swift test --disable-sandbox` *(fails: no such module 'SwiftUI')*

------
https://chatgpt.com/codex/tasks/task_e_68847c89ac84832aa248022c3ab47855